### PR TITLE
Consolidate event data json

### DIFF
--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -90,7 +90,7 @@ function queryFacebookApi(nodes) {
                 for (var i = 0; i < responseData.data.length; i++) {
                     responseData.data[i].organiser = organiserData;
                 }
-                s3Data = responseData;
+                s3Data = responseData.data;
             }
 
             aggregatedResponse.push(s3Data);

--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -86,6 +86,17 @@ function queryFacebookApi(nodes) {
             } else {
                 for (var i = 0; i < responseData.data.length; i++) {
                     responseData.data[i].organiser = organiserData;
+
+                    // entries with event_times really mess up the sorting, so replace the original id, start_time and end_time with the next upcoming event
+                    if(responseData.data[i].event_times){
+                        var firstUpcomingEvent = responseData.data[i].event_times.find((element) => {
+                            return (new Date(element.start_time).getTime() > Date.now();
+                        });
+
+                        responseData.data[i].id = firstUpcomingEvent.id;
+                        responseData.data[i].start_time = firstUpcomingEvent.start_time;
+                        responseData.data[i].end_time = firstUpcomingEvent.end_time;
+                    }
                     aggregatedResponse[responseData.data[i].id] = responseData.data[i]; // event ID should be unique, so duplicates can be overwritten
                 }
             }
@@ -200,7 +211,7 @@ function cleanupPayloadToS3(payload){
 
     console.log("cleaned payload content: ", cleanedPayload);
 
-    cleanedPayload.sort(function(left, right){   
+    cleanedPayload.sort(function(left, right){
         var leftDate = new Date(left.start_time);
         var rightDate = new Date(right.start_time);
 

--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -200,16 +200,16 @@ function cleanupPayloadToS3(payload){
 
     console.log("cleaned payload content: ", cleanedPayload);
 
-    // cleanedPayload.sort(function(left, right){   // FIXME: sorting causes a timeout, too much data?
-    //     var leftDate = new Date(left.start_time);
-    //     var rightDate = new Date(right.start_time);
-    //
-    //     if(!leftDate || !rightDate || leftDate.getTime() === rightDate.getTime()){
-    //         return 0;
-    //     }else{
-    //         return leftDate.getTime() < rightDate.getTime() ? -1 : 1;
-    //     }
-    // });
+    cleanedPayload.sort(function(left, right){   
+        var leftDate = new Date(left.start_time);
+        var rightDate = new Date(right.start_time);
+
+        if(!leftDate || !rightDate || leftDate.getTime() === rightDate.getTime()){
+            return 0;
+        }else{
+            return leftDate.getTime() < rightDate.getTime() ? -1 : 1;
+        }
+    });
 
     cleanedPayload = JSON.stringify(cleanedPayload);
     return cleanedPayload;

--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -71,6 +71,11 @@ function queryFacebookApi(nodes) {
 
     var pageEventsCallback = function(organiser, response) {
         var payload = "";
+
+        var firstFutureComparator = function(element){
+            return (new Date(element.start_time)).getTime() > Date.now();
+        };
+
         response.on("data", function(chunk) {
             payload += chunk;
         });
@@ -89,9 +94,7 @@ function queryFacebookApi(nodes) {
 
                     // entries with event_times really mess up the sorting, so replace the original id, start_time and end_time with the next upcoming event
                     if(responseData.data[i].event_times){
-                        var firstUpcomingEvent = responseData.data[i].event_times.find((element) => {
-                            return (new Date(element.start_time).getTime() > Date.now();
-                        });
+                        var firstUpcomingEvent = responseData.data[i].event_times.find(firstFutureComparator);
 
                         responseData.data[i].id = firstUpcomingEvent.id;
                         responseData.data[i].start_time = firstUpcomingEvent.start_time;
@@ -107,7 +110,7 @@ function queryFacebookApi(nodes) {
                 updateS3Data(aggregatedResponse);
             }
         });
-    }
+    };
 
     var groupFeedCallback = function(organiser, response) {
         var payload = "";
@@ -136,11 +139,11 @@ function queryFacebookApi(nodes) {
                 updateS3Data(aggregatedResponse);
             }
         });
-    }
+    };
 
     var errCallback = function(err) {
         console.log("problem with request: " + err);
-    }
+    };
 
     for (var node in nodes) {
         // foreach node: query FB for event data and replace the data in the corresponding S3 bucket

--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -197,20 +197,21 @@ function updateS3Data(payload) {
 }
 
 function cleanupPayloadToS3(payload){
-    var cleanedPayload = Object.values(payload); // TODO: object -> array method, should be built in?
+    // var cleanedPayload = Object.values(payload); // NB Object.values isn't available until Node 7.0
+    var cleanedPayload = Object.keys(payload).map((key) => { return payload[key]; });
 
-    cleanedPayload.sort(function(left, right){
-        var leftTime = new Date(left.start_time);
-        var rightTime = new Date(right.start_time);
+    // cleanedPayload.sort(function(left, right){   // FIXME: sorting causes a timeout, too much data?
+    //     var leftDate = new Date(left.start_time);
+    //     var rightDate = new Date(right.start_time);
+    //
+    //     if(!leftDate || !rightDate || leftDate.getTime() === rightDate.getTime()){
+    //         return 0;
+    //     }else{
+    //         return leftDate.getTime() < rightDate.getTime() ? -1 : 1;
+    //     }
+    // });
 
-        if(!leftTime || !rightTime || leftTime.getTime() === rightTime.getTime()){
-            return 0;
-        }else{
-            return leftDate.getTime() < rightDate.getTime() ? -1 : 1;
-        }
-    });
-
-    cleanedPayload = JSON.stringify(payload);
+    cleanedPayload = JSON.stringify(cleanedPayload);
     return cleanedPayload;
 }
 

--- a/bot_lambdas/updateStoredEventData.js
+++ b/bot_lambdas/updateStoredEventData.js
@@ -181,8 +181,6 @@ function queryFacebookApi(nodes) {
 function updateS3Data(payload) {
     var content = cleanupPayloadToS3(payload);
 
-    content = cleanupPayloadToS3(content);
-
     s3.putObject({
         Bucket: S3_BUCKET_NAME,
         Key: S3_EVENT_DATA_OBJECT_KEY,
@@ -199,6 +197,8 @@ function updateS3Data(payload) {
 function cleanupPayloadToS3(payload){
     // var cleanedPayload = Object.values(payload); // NB Object.values isn't available until Node 7.0
     var cleanedPayload = Object.keys(payload).map((key) => { return payload[key]; });
+
+    console.log("cleaned payload content: ", cleanedPayload);
 
     // cleanedPayload.sort(function(left, right){   // FIXME: sorting causes a timeout, too much data?
     //     var leftDate = new Date(left.start_time);


### PR DESCRIPTION
The event data storage has been restructured to be placed in one location in S3, so when polling Facebook the update stored data logic needs to consolidate all of this data into one structure before saving to S3.